### PR TITLE
I added flashcard class with validation and AF/RI

### DIFF
--- a/src/logic/flashcards.ts
+++ b/src/logic/flashcards.ts
@@ -58,3 +58,22 @@ Representation Invariant (RI):
 
 // TODO: Maybe later add createdAt timestamp?
 // TODO: Support markdown in front/back? (stretch goal)
+
+
+
+
+// Wrapper to create a Flashcard instance.
+// Keeps things cleaner wherever we’re generating new cards (especially outside the class file).
+// Feeds straight into the Flashcard constructor, which handles trimming + validation.
+
+// Note: throws if front/back are missing or any tag/hint is off,
+// so whoever’s calling this should probably catch errors if needed.
+export function createFlashcard(
+  front: string,
+  back: string,
+  hint?: string,
+  tags: string[] = []
+): Flashcard {
+  return new Flashcard(front, back, hint, tags); // pretty much just passes through for now
+}
+

--- a/src/logic/flashcards.ts
+++ b/src/logic/flashcards.ts
@@ -1,18 +1,60 @@
+// Flashcard class: It is a simple Q&A card with optional hints and tags.
+// (Might tweak this later if we want categories or difficulty levels...)
+
 export class Flashcard {
-  constructor(
-    readonly front: string,
-    readonly back: string,
-    readonly hint?: string,
-    readonly tags: ReadonlyArray<string> = []
-  ) {}
+  readonly id: string;
+  readonly front: string;
+  readonly back: string;
+  readonly hint?: string;
+  readonly tags: ReadonlyArray<string>;
+
+  constructor(frontSide: string, backSide: string, hintText?: string, tagList: ReadonlyArray<string> = []) {
+    // Assign a random ID (hope crypto is supported everywhere...)
+    this.id = crypto.randomUUID();
+
+    this.front = frontSide.trim();
+    this.back = backSide.trim();
+    this.hint = hintText?.trim(); // Its fine if no hint is passed
+    this.tags = tagList;
+
+    this._validateFlashcard(); // sanity check - make sure its not totally broken
+  }
+
+  //internal check to make sure the card isn't missing required stuff
+  private _validateFlashcard(): void {
+    if (!this.front) {
+      throw new Error("Front side cannot be empty. Otherwise, what's the question?");
+    }
+    if (!this.back) {
+      throw new Error("Back side must have an answer. (duh)");
+    }
+    if (this.hint !== undefined && this.hint.length === 0) {
+      throw new Error("If you give hint, it should actually hint something.");
+    }
+
+    if (!Array.isArray(this.tags)) {
+      throw new Error("Tags should be list.Even if it's empty.");
+    }
+
+    // little paranoid loop just to make sure tags make sense
+    for (let t of this.tags) {
+      if (typeof t !== "string" || t.trim() === "") {
+        throw new Error("Every tag need to be non-empty string. No ghost tags.");
+      }
+    }
+  }
 }
 
-export enum AnswerDifficulty {
-  Wrong = 0,
-  Hard = 1,
-  Easy = 2,
-}
+/*
+Abstraction Function (AF):
+- Think of a Flashcard like a study helper: front = question, back = answer, plus maybe a hint or some tags to keep organized.
 
-// Buckets are numbered starting from 0
-// Bucket 0 contains new cards and cards that were answered incorrectly
-export type BucketMap = Map<number, Set<Flashcard>>;
+Representation Invariant (RI):
+- front and back must have actual text.
+- hint must be meaningful if it exists.
+- tags must be a proper array of non-empty strings.
+- id is assigned at creation and should stay unique.
+*/
+
+// TODO: Maybe later add createdAt timestamp?
+// TODO: Support markdown in front/back? (stretch goal)


### PR DESCRIPTION
Added flashcard class to represent study cards with front (question), back (answer), optional hint and tags.

Main stuff:
- set up front/back text with trimming
- generates unique ID for each flashcard (using crypto.randomUUID)
- Built-in validation (_validateFlashcard) to catch missing or bad data early
- Added AF and RI comments for future maintainability
- tags and hint are optional but supported

Notes:
- Validation errs on the strict side to avoid weird empty cards
- Might add createdAt or markdown support later if needed
- Kept the constructor pretty straightforward for now

should be good to build on if we want decks or study sessions later.
