### PR TITLE
Extend Flashcards logic with helpers, practice/update, and gethint, computeprogress features.

### DIFF
--- a/src/logic/algorithm.ts
+++ b/src/logic/algorithm.ts
@@ -1,92 +1,147 @@
 import { AnswerDifficulty, BucketMap, Flashcard } from "./flashcards";
 
-export function toBucketsSets(bucketNumbers: BucketMap) {
-  const result: Set<Flashcard>[] = [];
-
-  for (const [bucketNum, cards] of bucketNumbers.entries()) {
-    if (bucketNum < 0) {
-      throw new Error("Bucket index, must be a nonnegative number.");
-    }
-
-    result[bucketNum] = cards;
-  }
-
-  return result;
-}
-
-export function practice(
-  day: number,
-  buckets: Set<Flashcard>[]
-): Set<Flashcard> {
+// Selects flashcards to practice today based on the day.
+// - Always practice Bucket 0 (new/wrong)
+// - Higher buckets shown every 2^bucketNumber days
+export function practice(day: number, bucketMap: BucketMap): Set<Flashcard> {
   if (day < 1) {
-    throw new Error("Day of the learning process, must be >= 1.");
+    throw new Error("day must be >= 1.");
   }
 
-  const result = new Set<Flashcard>();
+  const cardsToPractice = new Set<Flashcard>();
 
-  if (buckets[0]) {
-    for (const card of buckets[0]) {
-      result.add(card);
-    }
-  }
-
-  for (let bucketNum = 1; bucketNum < buckets.length; bucketNum++) {
-    const interval = Math.pow(2, bucketNum);
-    if (day % interval === 0 && buckets[bucketNum]) {
-      for (const card of buckets[bucketNum]) {
-        result.add(card);
+  for (const [bucketNumber, flashcards] of bucketMap.entries()) {
+    if (bucketNumber === 0) {
+      for (const card of flashcards) {
+        cardsToPractice.add(card);
+      }
+    } else {
+      const interval = Math.pow(2, bucketNumber);
+      if (day % interval === 0) {
+        for (const card of flashcards) {
+          cardsToPractice.add(card);
+        }
       }
     }
   }
 
-  return result;
+  return cardsToPractice;
 }
 
-export function getHint(card: Flashcard): string {
-  if (card.hint) {
-    return card.hint;
-  }
-
-  throw new Error("No hint available for this card.");
-}
-
+// Updates a flashcard's bucket based on answer difficulty.
+// - Wrong ➔ Bucket 0
+// - Hard ➔ Stay in same bucket
+// - Easy ➔ Move to next higher bucket
 export function update(
-  buckets: BucketMap,
+  bucketMap: BucketMap,
   card: Flashcard,
   difficulty: AnswerDifficulty
 ): BucketMap {
   const newBuckets = new Map<number, Set<Flashcard>>();
+  let currentBucketNumber: number | null = null;
 
-  let currentBucket = -1;
-  for (const [bucketNum, cards] of buckets.entries()) {
-    const newSet = new Set<Flashcard>(cards);
-    newBuckets.set(bucketNum, newSet);
+  for (const [bucketNumber, cards] of bucketMap.entries()) {
+    const copiedCards = new Set<Flashcard>(cards);
+    newBuckets.set(bucketNumber, copiedCards);
 
     if (cards.has(card)) {
-      currentBucket = bucketNum;
+      currentBucketNumber = bucketNumber;
     }
   }
 
-  if (currentBucket === -1 && !newBuckets.has(0)) {
-    newBuckets.set(0, new Set<Flashcard>());
-  } else if (currentBucket !== -1) {
-    const currentSet = newBuckets.get(currentBucket)!;
-    currentSet.delete(card);
+  if (currentBucketNumber === null) {
+    throw new Error("card not found in any bucket.");
   }
 
-  let newBucket: number;
+  newBuckets.get(currentBucketNumber)!.delete(card);
+
+  let targetBucketNumber: number;
   if (difficulty === AnswerDifficulty.Wrong) {
-    newBucket = 0;
+    targetBucketNumber = 0;
   } else if (difficulty === AnswerDifficulty.Hard) {
-    newBucket = currentBucket;
+    targetBucketNumber = currentBucketNumber;
   } else {
-    newBucket = currentBucket + 1;
+    targetBucketNumber = currentBucketNumber + 1;
   }
 
-  if (!newBuckets.has(newBucket)) {
-    newBuckets.set(newBucket, new Set<Flashcard>());
+  if (!newBuckets.has(targetBucketNumber)) {
+    newBuckets.set(targetBucketNumber, new Set<Flashcard>());
   }
-  newBuckets.get(newBucket)!.add(card);
+
+  newBuckets.get(targetBucketNumber)!.add(card);
 
   return newBuckets;
+}
+
+
+// Builds a hint from the flashcard if none exists
+export function getHint(card: Flashcard): string {
+  if (card.hint && card.hint.trim() !== "") {
+    return card.hint;
+  }
+
+  const answerWords = card.back.split(/\s+/);
+
+  const maskedWords = answerWords.map((word) => {
+    if (word.length === 0) return "";
+    return word[0] + "_".repeat(word.length - 1);
+  });
+
+  return maskedWords.join(" ");
+}
+
+// Computes basic progress stats based on buckets and practice history
+export function computeProgress(
+  buckets: BucketMap,
+  history: Array<{
+    card: Flashcard;
+    timestamp: number;
+    difficulty: AnswerDifficulty;
+  }>
+): {
+  totalCards: number;
+  cardsPerBucket: Map<number, number>;
+  averageBucket: number;
+  masteredCards: number;
+  successRate: number;
+} {
+  let totalCards = 0;
+  const cardsPerBucket = new Map<number, number>();
+
+  for (const [bucket, cards] of buckets.entries()) {
+    const count = cards.size;
+    totalCards += count;
+    cardsPerBucket.set(bucket, count);
+  }
+
+  let bucketSum = 0;
+  for (const [bucket, count] of cardsPerBucket.entries()) {
+    bucketSum += bucket * count;
+  }
+
+  const averageBucket = totalCards > 0 ? bucketSum / totalCards : 0;
+
+  let masteredCards = 0;
+  for (const [bucket, count] of cardsPerBucket.entries()) {
+    if (bucket >= 3) {
+      masteredCards += count;
+    }
+  }
+
+  let successCount = 0;
+  for (const entry of history) {
+    if (entry.difficulty !== AnswerDifficulty.Wrong) {
+      successCount++;
+    }
+  }
+
+  const successRate = history.length > 0 ? (successCount / history.length) * 100 : 0;
+
+  return {
+    totalCards,
+    cardsPerBucket,
+    averageBucket,
+    masteredCards,
+    successRate,
+  };
 }

--- a/src/logic/flashcards.ts
+++ b/src/logic/flashcards.ts
@@ -1,18 +1,85 @@
+// Flashcard class: simple Q&A card with optional hint and tags.
 export class Flashcard {
-  constructor(
-    readonly front: string,
-    readonly back: string,
-    readonly hint?: string,
-    readonly tags: ReadonlyArray<string> = []
-  ) {}
+  readonly id: string;
+  readonly front: string;
+  readonly back: string;
+  readonly hint?: string;
+  readonly tags: ReadonlyArray<string>;
+
+  constructor(frontSide: string, backSide: string, hintText?: string, tagList: ReadonlyArray<string> = []) {
+    this.id = crypto.randomUUID();
+    this.front = frontSide.trim();
+    this.back = backSide.trim();
+    this.hint = hintText?.trim();
+    this.tags = tagList;
+    this._validateFlashcard();
+  }
+
+  // Checks that front/back exist and tags are valid.
+  private _validateFlashcard(): void {
+    if (!this.front) {
+      throw new Error("front side cannot be empty.");
+    }
+    if (!this.back) {
+      throw new Error("back side must have an answer.");
+    }
+    if (this.hint !== undefined && this.hint.length === 0) {
+      throw new Error("hint must not be empty.");
+    }
+    if (!Array.isArray(this.tags)) {
+      throw new Error("tags must be an array.");
+    }
+    for (let t of this.tags) {
+      if (typeof t !== "string" || t.trim() === "") {
+        throw new Error("tags must be non-empty strings.");
+      }
+    }
+  }
 }
 
+/*
+AF:
+- Flashcard = front (question), back (answer), optional hint and tags.
+
+RI:
+- front and back must not be empty.
+- tags must be an array of non-empty strings.
+- id is unique per card.
+*/
+
+// Creates a Flashcard instance with basic validation.
+export function createFlashcard(
+  front: string,
+  back: string,
+  hint?: string,
+  tags: string[] = []
+): Flashcard {
+  return new Flashcard(front, back, hint, tags);
+}
+
+// Adds a Flashcard to Bucket 0 (creates it if missing).
+export function addCardToBucket(bucketMap: BucketMap, card: Flashcard): void {
+  if (!bucketMap.has(0)) {
+    bucketMap.set(0, new Set<Flashcard>());
+  }
+
+  const bucketZero = bucketMap.get(0)!;
+
+  if (bucketZero.has(card)) {
+    throw new Error("card already exists in Bucket 0.");
+  }
+
+  bucketZero.add(card);
+}
+
+// --- Types for working with Flashcards ---
+
+// User's answer rating after a flashcard.
 export enum AnswerDifficulty {
   Wrong = 0,
   Hard = 1,
   Easy = 2,
 }
 
-// Buckets are numbered starting from 0
-// Bucket 0 contains new cards and cards that were answered incorrectly
+// Map of buckets for spaced repetition (0 = new cards).
 export type BucketMap = Map<number, Set<Flashcard>>;


### PR DESCRIPTION
Implemented core helpers and logic for flashcards management, including some bonus features for extended functionality.

What was done:

- Added addCardToBucket() helpers
- Implemented practice() function for spaced repetition review
- Implemented update() function for moving flashcards based on answers
- Added getHint() helper to generate hints when needed
- Added computeProgress() helper for tracking learning statistics
- Defined AnswerDifficulty enum and BucketMap type for structure
- Polished comments across flashcards.ts and algorithm.ts for clarity
